### PR TITLE
Remove Gemfile.lock from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
+Gemfile.lock


### PR DESCRIPTION
We're getting security warnings about dependencies based on what's "installed" in the Gemfile lock. But as a gem itself, we aren't actually depending on the gem versions which are tripping the security warnings; they're just which versions got installed last time we ran `bundle`. There's no need for that, or to force end users/contributors to work with an arbitrary set of dependency versions.